### PR TITLE
Add postBuild

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,1 @@
+pip install scikit-learn

--- a/postBuild
+++ b/postBuild
@@ -1,1 +1,3 @@
+#!/bin/bash
+
 pip install scikit-learn


### PR DESCRIPTION
Adding postBuild file, which installs scikit-learn in the binder docker image.
Since scikit-learn is not a requirement, this is an awesome way to still import another package.