### PR TITLE
Lazy load matplotlib

### DIFF
--- a/kneed/knee_locator.py
+++ b/kneed/knee_locator.py
@@ -124,7 +124,7 @@ class KneeLocator(object):
 
     def plot_knee_normalized(self, ):
         import matplotlib.pyplot as plt
-        
+
         plt.figure(figsize=(8, 8))
         plt.plot(self.xsn, self.ysn)
         plt.plot(self.xd, self.yd, 'r')

--- a/kneed/knee_locator.py
+++ b/kneed/knee_locator.py
@@ -1,7 +1,6 @@
 import numpy as np
 from scipy import interpolate
 from scipy.signal import argrelextrema
-import matplotlib.pyplot as plt
 
 
 class KneeLocator(object):
@@ -124,6 +123,8 @@ class KneeLocator(object):
         return knee_, norm_knee_, knee_x
 
     def plot_knee_normalized(self, ):
+        import matplotlib.pyplot as plt
+        
         plt.figure(figsize=(8, 8))
         plt.plot(self.xsn, self.ysn)
         plt.plot(self.xd, self.yd, 'r')
@@ -133,6 +134,8 @@ class KneeLocator(object):
         plt.vlines(self.norm_knee, plt.ylim()[0], plt.ylim()[1])
 
     def plot_knee(self, ):
+        import matplotlib.pyplot as plt
+
         plt.figure(figsize=(8, 8))
         plt.plot(self.x, self.y)
         plt.vlines(self.knee, plt.ylim()[0], plt.ylim()[1])


### PR DESCRIPTION
Importing *matplotlib* only when needed allows people to use *kneed* without a framework build of Python. Since it isn't needed for the functionality itself, it should be imported only if one tries to plot something.