### PR TITLE
Fixed docstring and added elbow properties to complement knees

### DIFF
--- a/kneed/knee_locator.py
+++ b/kneed/knee_locator.py
@@ -11,7 +11,8 @@ class KneeLocator(object):
         x = x values
         y = y values
         S = Sensitivity parameter, original paper suggests default of 1.0
-        curve = If True, algorithm will detect elbows instead of knees.
+        curve = If 'concave', algorithm will detect knees. If 'convex', it
+            will detect elbows.
         direction = {"increasing", "decreasing"}
         """
         # Step 0: Raw Input
@@ -126,3 +127,18 @@ class KneeLocator(object):
         plt.figure(figsize=(8, 8))
         plt.plot(self.x, self.y)
         plt.vlines(self.knee, plt.ylim()[0], plt.ylim()[1])
+
+    # Niceties for users working with elbows rather than knees
+
+    @property
+    def elbow(self):
+        return self.knee
+
+    @property
+    def norm_elbow(self):
+        return self.norm_knee
+
+    @property
+    def elbow_x(self):
+        return self.knee_x
+


### PR DESCRIPTION
Fixed the parameter descriptions in the KneeLocator docstring.

Also added some elbow properties; all they do is return the corresponding knee values, but it means your code looks a bit nicer if you're looking for elbows and everything else references 'elbows'.