### PR TITLE
Update for numpy adjustments

### DIFF
--- a/kneed/knee_locator.py
+++ b/kneed/knee_locator.py
@@ -99,11 +99,11 @@ class KneeLocator(object):
             y = y.max() - y
         # flip decreasing functions to increasing
         if direction == 'decreasing':
-            y = np.flip(y)
+            y = np.flip(y, axis=0)
 
         if curve == 'convex':
-            x = np.flip(x)
-            y = np.flip(y)
+            x = np.flip(x, axis=0)
+            y = np.flip(y, axis=0)
 
         return x, y
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 matplotlib
-numpy
+numpy>=1.15.0
 scikit-learn
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 matplotlib
-numpy>=1.15.0
+numpy>=1.14.2
+pytest
 scikit-learn
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 matplotlib
 numpy>=1.14.2
-pytest
 scikit-learn
 scipy

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -137,3 +137,10 @@ def test_sine():
         kl_sine = KneeLocator(x, y_sin, direction=direction, curve=curve, S=1)
         detected_knees.extend(kl_sine.all_knees)
     assert np.isclose(expected_knees, detected_knees).all()
+
+
+def test_list_input():
+    """Indirectly test that flip works on lists as input"""
+    x, y = dg.figure2()
+    kl = KneeLocator(x.tolist(), y.tolist(), S=1.0, curve='concave', interp_method='polynomial')
+    assert math.isclose(kl.knee, 0.22, rel_tol=0.05)


### PR DESCRIPTION
If numpy v1.14.x is used, there will be this message:
`flip() missing 1 required positional argument: ‘axis’`