### PR TITLE
Adding VERSION to MANIFEST.in and add include_package_data to setup.cfg

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include LICENSE
 include README.md
 include requirements.txt
 include tests/test_sample.py
+include kneed/VERSION

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ classifiers =
 [options]
 packages = kneed
 install_requires = file: requirements.txt
+include_package_data = True
 
 [options.extras_require]
 plot = matplotlib>=2.2.5


### PR DESCRIPTION
Before these changes when trying to build, I got the following error.

`python -m build`

```python
...
distutils.errors.DistutilsOptionError: Version loaded from file: kneed/VERSION does not comply with PEP 440:

ERROR Backend subprocess exited when trying to invoke get_requires_for_build_wheel
```

After these changes, the package builds successfully.