### PR TITLE
remove MANIFEST file, it is not used with hatch

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,0 @@
-include LICENSE
-include README.md
-include requirements.txt
-include tests/test_sample.py
-include kneed/VERSION


### PR DESCRIPTION
Hi,

just removed this obsolete manifest. Since switch to hatchling it is not used anymore. Respective info is now in pyproject.toml. Was confusing for me.