### PR TITLE
Fix index error in online knee finding

### DIFF
--- a/kneed/knee_locator.py
+++ b/kneed/knee_locator.py
@@ -262,7 +262,7 @@ class KneeLocator(object):
             j = i + 1
 
             # reached the end of the curve
-            if x == 1.0:
+            if i == (len(self.x_difference) - 1):
                 break
 
             # if we're at a local max, increment the maxima threshold index and continue


### PR DESCRIPTION
As mentioned in issue #119, in online knee finding it's possible to get an index error. I changed the test for reaching the end of the curve to avoid the index error.